### PR TITLE
Allow to control sealing module visibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sealed"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["José Duarte <jmg.duarte@campus.fct.unl.pt>"]
 license = "MIT OR Apache-2.0"
 description = "Macro for sealing traits and structures"

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ impl T for B {}
 pub struct C;
 
 impl T for C {} // compile error
-
-fn main() {
-    return
-}
 ```
 
 ## Arguments
@@ -80,10 +76,6 @@ pub struct B(i32);
 impl T for A {}
 #[sealed]
 impl T for B {}
-
-fn main() {
-    return;
-}
 ```
 
 ### Expanded
@@ -104,8 +96,4 @@ impl T for A {}
 
 impl __seal_t::Sealed for B {}
 impl T for B {}
-
-fn main() {
-    return;
-}
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ as described in the Rust API Guidelines [[1](https://rust-lang.github.io/api-gui
 
 ```toml
 [dependencies]
-sealed = "0.2.1"
+sealed = "0.3"
 ```
 
 ## Example
@@ -45,12 +45,13 @@ fn main() {
 }
 ```
 
-## Attributes
+## Arguments
 
-This is the list of attributes that can be used along `#[sealed]`:
-- `#[sealed]`: the main attribute macro, without attribute parameters.
-- `#[sealed(erase)]`: this option turns on bound erasure. This is useful when using the `#[sealed]` macro inside a function.
-For an example, see [`bound-erasure-fn`](tests/pass/08-bound-erasure-fn.rs).
+This is the list of arguments that can be used in a `#[sealed]` attribute:
+
+- `#[sealed(erase)]`: turns on trait bounds erasure. This is useful when using the `#[sealed]` macro inside a function. For an example, see [`bound-erasure-fn`](examples/bound-erasure-fn.rs) example.
+  
+- `#[sealed(pub(crate))]` or `#[sealed(pub(in some::path))]`: allows to tune visibility of the generated sealing module. This useful when the trait and its impls are defined in different modules. For an example, see [`nesting`](examples/nesting.rs) example. **Notice**, that just `pub` is disallowed as breaks the whole idea of sealing.
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is the list of arguments that can be used in a `#[sealed]` attribute:
 
 - `#[sealed(erase)]`: turns on trait bounds erasure. This is useful when using the `#[sealed]` macro inside a function. For an example, see [`bound-erasure-fn`](examples/bound-erasure-fn.rs) example.
   
-- `#[sealed(pub(crate))]` or `#[sealed(pub(in some::path))]`: allows to tune visibility of the generated sealing module. This useful when the trait and its impls are defined in different modules. For an example, see [`nesting`](examples/nesting.rs) example. **Notice**, that just `pub` is disallowed as breaks the whole idea of sealing.
+- `#[sealed(pub(crate))]` or `#[sealed(pub(in some::path))]`: allows to tune visibility of the generated sealing module (the default one is private). This useful when the trait and its impls are defined in different modules. For an example, see [`nesting`](examples/nesting.rs) example. **Notice**, that just `pub` is disallowed as breaks the whole idea of sealing.
 
 ## Details
 

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,5 +1,7 @@
-use sealed::sealed;
 use std::marker::PhantomData;
+
+use sealed::sealed;
+
 #[sealed]
 pub trait DroneState {}
 

--- a/examples/bound-erasure.rs
+++ b/examples/bound-erasure.rs
@@ -1,5 +1,8 @@
 use sealed::sealed;
+
 trait Foo {}
+
 #[sealed(erase)]
 trait Trait<T: ?Sized + Foo> {}
+
 fn main() {}

--- a/examples/nesting.rs
+++ b/examples/nesting.rs
@@ -5,7 +5,7 @@ mod lets {
         pub mod some {
             pub mod nesting {
                 use sealed::sealed;
-                #[sealed]
+                #[sealed(pub(crate))]
                 pub trait LongerSnakeCaseType {}
             }
         }
@@ -22,6 +22,4 @@ impl lets::attempt::some::nesting::LongerSnakeCaseType for A {}
 #[sealed]
 impl lets::attempt::some::nesting::LongerSnakeCaseType for B {}
 
-fn main() {
-    return;
-}
+fn main() {}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -11,6 +11,4 @@ impl T for A {}
 #[sealed]
 impl T for B {}
 
-fn main() {
-    return;
-}
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,10 @@ impl Parse for TraitArguments {
                     if matches!(out.visibility, syn::Visibility::Public(_)) {
                         return Err(syn::Error::new(
                             out.visibility.span(),
-                            "seal with `pub` visibility is nonsense",
+                            "`pub` visibility breaks the seal as allows to use \
+                             it outside its crate.\n\
+                             Consider tightening the visibility (e.g. \
+                             `pub(crate)`) if you actually need sealing.",
                         ));
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,9 @@
 //!
 //! ### `pub(crate)` or `pub(in some::path)`
 //!
-//! Allows to tune visibility of the generated sealing module. This useful when
-//! the trait and its impls are defined in different modules.
+//! Allows to tune visibility of the generated sealing module (the default one
+//! is private). This useful when the trait and its impls are defined in
+//! different modules.
 //!
 //! ```rust
 //! # use sealed::sealed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! sealed = "0.1"
+//! sealed = "0.3"
 //! ```
 //!
 //! ## Example
@@ -19,106 +19,135 @@
 //! You can see a demo in [`demo/`](demo/).
 //!
 //! ```rust,compile_fail
-//! use sealed::sealed;
-//!
+//! # use sealed::sealed;
+//! #
 //! #[sealed]
 //! trait T {}
 //!
-//! #[sealed]
 //! pub struct A;
-//!
+//! #[sealed]
 //! impl T for A {}
 //!
-//! #[sealed]
 //! pub struct B;
-//!
+//! #[sealed]
 //! impl T for B {}
 //!
 //! pub struct C;
-//!
 //! impl T for C {} // compile error
 //! ```
 //!
 //! ## Details
 //!
-//! The macro generates a `private` module when attached to a `trait`
-//! (this raises the limitation that the `#[sealed]` macro can only be added to a single trait per module),
-//! when attached to a `struct` the generated code simply implements the sealed trait for the respective structure.
-//!
-//!
-//! ### Expansion
+//! The attribute generates a private uniquely named module when attached to a
+//! trait definition, when attached to an `impl` block the generated code simply
+//! implements the sealed trait for the respective type.
 //!
 //! ```rust
 //! // #[sealed]
 //! // trait T {}
-//! trait T: private::Sealed {}
-//! mod private {
+//! trait T: __seal_t::Sealed {}
+//! mod __seal_t {
 //!     pub trait Sealed {}
 //! }
 //!
-//! // #[sealed]
-//! // pub struct A;
 //! pub struct A;
-//! impl private::Sealed for A {}
+//!
+//! // #[sealed]
+//! // impl T for A {}
+//! impl T for A {}
+//! impl __seal_t::Sealed for A {}
 //! ```
+//!
+//! ## Arguments
+//!
+//! The expanded code may be customized with the following attribute arguments.
+//!
+//! ### `erase`
+//!
+//! Turns on trait bounds erasure. This is useful when using the `#[sealed]`
+//! attribute inside a function. By default, all the bounds are propagated to
+//! the generated `Sealed` trait.
+//!
+//! ```rust
+//! // #[sealed(erase)]
+//! // trait Trait<T: ?Sized + Default> {}
+//! trait Trait<T: ?Sized + Default>: __seal_trait::Sealed<T> {}
+//! mod __seal_trait {
+//!     pub trait Sealed<T> {}
+//! }
+//! ```
+//!
+//! ### `pub(crate)` or `pub(in some::path)`
+//!
+//! Allows to tune visibility of the generated sealing module. This useful when
+//! the trait and its impls are defined in different modules.
+//!
+//! ```rust
+//! # use sealed::sealed;
+//! #
+//! mod lets {
+//!     pub mod attempt {
+//!         pub mod some {
+//!             pub mod nesting {
+//! #               use sealed::sealed;
+//!                 #[sealed(pub(in super::super::super::super))]
+//!                 pub trait T {}
+//!             }
+//!         }
+//!     }
+//! }
+//!
+//! pub struct A;
+//! #[sealed]
+//! impl lets::attempt::some::nesting::T for A {}
+//! ```
+//!
+//! Notice, that just `pub` is disallowed as breaks the whole idea of sealing.
+//!
+//! ```rust,compile_fail
+//! # use sealed::sealed;
+//! #
+//! #[sealed(pub)] // compile error
+//! trait T {}
+//!
+//! pub struct A;
+//! #[sealed]
+//! impl T for A {}
+//! ```
+
+use std::fmt;
 
 use heck::SnakeCase;
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
-use syn::{ext::IdentExt, parse_macro_input, parse_quote};
-
-const TRAIT_ERASURE_ARG_IDENT: &str = "erase";
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{format_ident, quote};
+use syn::{
+    ext::IdentExt,
+    parse::{Parse, ParseStream},
+    parse_macro_input, parse_quote,
+    spanned::Spanned,
+    token,
+};
 
 #[proc_macro_attribute]
 pub fn sealed(args: TokenStream, input: TokenStream) -> TokenStream {
-    let erased = parse_macro_input!(args as Option<syn::Ident>);
-    let input = parse_macro_input!(input as syn::Item);
-    if let Some(erased) = erased {
-        if erased == TRAIT_ERASURE_ARG_IDENT {
-            match parse_sealed(input, true) {
-                Ok(ts) => ts,
-                Err(err) => err.to_compile_error(),
-            }
-        } else {
-            syn::Error::new_spanned(
-                erased,
-                format!(
-                    "The only accepted argument is `{}`.",
-                    TRAIT_ERASURE_ARG_IDENT
-                ),
-            )
-            .to_compile_error()
+    match parse_macro_input!(input) {
+        syn::Item::Impl(item_impl) => parse_sealed_impl(&item_impl),
+        syn::Item::Trait(item_trait) => {
+            Ok(parse_sealed_trait(item_trait, parse_macro_input!(args)))
         }
-    } else {
-        match parse_sealed(input, false) {
-            Ok(ts) => ts,
-            Err(err) => err.to_compile_error(),
-        }
+        _ => Err(syn::Error::new(Span::call_site(), "expected impl or trait")),
     }
+    .unwrap_or_else(|e| e.to_compile_error())
     .into()
 }
 
-fn seal_name<D: ::std::fmt::Display>(seal: D) -> syn::Ident {
-    ::quote::format_ident!("__seal_{}", &seal.to_string().to_snake_case())
-}
-
-fn parse_sealed(item: syn::Item, erase: bool) -> syn::Result<TokenStream2> {
-    match item {
-        syn::Item::Impl(item_impl) => parse_sealed_impl(&item_impl),
-        syn::Item::Trait(item_trait) => Ok(parse_sealed_trait(item_trait, erase)),
-        _ => Err(syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "expected impl or trait",
-        )),
-    }
-}
-
 // Care for https://gist.github.com/Koxiaet/8c05ebd4e0e9347eb05f265dfb7252e1#procedural-macros-support-renaming-the-crate
-fn parse_sealed_trait(mut item_trait: syn::ItemTrait, erase: bool) -> TokenStream2 {
+fn parse_sealed_trait(mut item_trait: syn::ItemTrait, args: TraitArguments) -> TokenStream2 {
     let trait_ident = &item_trait.ident.unraw();
     let trait_generics = &item_trait.generics;
     let seal = seal_name(trait_ident);
+    let vis = &args.visibility;
 
     let type_params = trait_generics
         .type_params()
@@ -126,12 +155,11 @@ fn parse_sealed_trait(mut item_trait: syn::ItemTrait, erase: bool) -> TokenStrea
 
     item_trait
         .supertraits
-        .push(parse_quote!(#seal::Sealed <#(#type_params, )*>));
+        .push(parse_quote!( #seal::Sealed <#(#type_params, )*> ));
 
-    if erase {
+    let mod_code = if args.erased {
         let lifetimes = trait_generics.lifetimes();
         let const_params = trait_generics.const_params();
-
         let type_params =
             trait_generics
                 .type_params()
@@ -139,22 +167,22 @@ fn parse_sealed_trait(mut item_trait: syn::ItemTrait, erase: bool) -> TokenStrea
                     parse_quote!( #ident : ?Sized )
                 });
 
-        quote!(
-            #[automatically_derived]
-            pub(crate) mod #seal {
-                pub trait Sealed< #(#lifetimes ,)* #(#type_params ,)* #(#const_params ,)* > {}
-            }
-            #item_trait
-        )
+        quote! {
+            pub trait Sealed< #(#lifetimes ,)* #(#type_params ,)* #(#const_params ,)* > {}
+        }
     } else {
-        quote!(
-            #[automatically_derived]
-            pub(crate) mod #seal {
-                use super::*;
-                pub trait Sealed #trait_generics {}
-            }
-            #item_trait
-        )
+        quote! {
+            use super::*;
+            pub trait Sealed #trait_generics {}
+        }
+    };
+
+    quote! {
+        #[automatically_derived]
+        #vis mod #seal {
+            #mod_code
+        }
+        #item_trait
     }
 }
 
@@ -162,7 +190,7 @@ fn parse_sealed_impl(item_impl: &syn::ItemImpl) -> syn::Result<TokenStream2> {
     let impl_trait = item_impl
         .trait_
         .as_ref()
-        .ok_or_else(|| syn::Error::new_spanned(item_impl, "missing implentation trait"))?;
+        .ok_or_else(|| syn::Error::new_spanned(item_impl, "missing implementation trait"))?;
 
     let mut sealed_path = impl_trait.1.segments.clone();
 
@@ -170,7 +198,7 @@ fn parse_sealed_impl(item_impl: &syn::ItemImpl) -> syn::Result<TokenStream2> {
     // thus both `first` and `last` are safe to unwrap
     let syn::PathSegment { ident, arguments } = sealed_path.pop().unwrap().into_value();
     let seal = seal_name(ident.unraw());
-    sealed_path.push(parse_quote!(#seal));
+    sealed_path.push(parse_quote!( #seal ));
     sealed_path.push(parse_quote!(Sealed));
 
     let self_type = &item_impl.self_ty;
@@ -184,4 +212,79 @@ fn parse_sealed_impl(item_impl: &syn::ItemImpl) -> syn::Result<TokenStream2> {
         impl #trait_generics #sealed_path #arguments for #self_type #where_clauses {}
         #item_impl
     })
+}
+
+/// Constructs [`syn::Ident`] of a sealing module name.
+fn seal_name<D: fmt::Display>(seal: D) -> syn::Ident {
+    format_ident!("__seal_{}", &seal.to_string().to_snake_case())
+}
+
+/// Arguments accepted by `#[sealed]` attribute when placed on a trait
+/// definition.
+struct TraitArguments {
+    /// `erase` argument indicating whether trait bounds erasure should be used.
+    ///
+    /// Default is `false`.
+    erased: bool,
+
+    /// `pub` argument defining visibility of the generated sealing module.
+    ///
+    /// Default is [`syn::Visibility::Inherited`].
+    visibility: syn::Visibility,
+}
+
+impl Default for TraitArguments {
+    fn default() -> Self {
+        Self {
+            erased: false,
+            visibility: syn::Visibility::Inherited,
+        }
+    }
+}
+
+impl Parse for TraitArguments {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut out = Self::default();
+
+        while !input.is_empty() {
+            let ident = syn::Ident::parse_any(&input.fork())?;
+
+            match ident.to_string().as_str() {
+                "erase" => {
+                    syn::Ident::parse_any(input)?;
+                    out.erased = true;
+                }
+
+                "pub" => {
+                    out.visibility = input.parse()?;
+                    if matches!(out.visibility, syn::Visibility::Public(_)) {
+                        return Err(syn::Error::new(
+                            out.visibility.span(),
+                            "seal with `pub` visibility is nonsense",
+                        ));
+                    }
+                }
+
+                unknown => {
+                    return Err(syn::Error::new(
+                        ident.span(),
+                        format!("unknown `{}` attribute argument", unknown),
+                    ))
+                }
+            }
+
+            if input
+                .lookahead1()
+                .peek(token::Comma)
+                .then(|| input.parse::<token::Comma>())
+                .transpose()?
+                .is_none()
+                && !input.is_empty()
+            {
+                return Err(syn::Error::new(ident.span(), "expected followed by `,`"));
+            }
+        }
+
+        Ok(out)
+    }
 }

--- a/tests/fail/01-general.rs
+++ b/tests/fail/01-general.rs
@@ -19,6 +19,4 @@ impl T for B {}
 
 impl T for C {}
 
-fn main() {
-    return;
-}
+fn main() {}

--- a/tests/fail/02-nesting.stderr
+++ b/tests/fail/02-nesting.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `C: Sealed` is not satisfied
   --> $DIR/02-nesting.rs:26:6
    |
-8  |                 #[sealed]
-   |                 --------- required by this bound in `T`
+8  |                 #[sealed(pub(crate))]
+   |                 --------------------- required by this bound in `T`
 9  |                 pub trait T {}
    |                           - required by a bound in this
 ...

--- a/tests/fail/03-private-by-default.rs
+++ b/tests/fail/03-private-by-default.rs
@@ -5,7 +5,7 @@ mod lets {
         pub mod some {
             pub mod nesting {
                 use sealed::sealed;
-                #[sealed(pub(crate))]
+                #[sealed]
                 pub trait T {}
             }
         }
@@ -13,16 +13,8 @@ mod lets {
 }
 
 pub struct A;
-pub struct B {
-    field_1: i32,
-}
-pub struct C;
 
 #[sealed]
 impl lets::attempt::some::nesting::T for A {}
-#[sealed]
-impl lets::attempt::some::nesting::T for B {}
-// fails to compile
-impl lets::attempt::some::nesting::T for C {}
 
 fn main() {}

--- a/tests/fail/03-private-by-default.stderr
+++ b/tests/fail/03-private-by-default.stderr
@@ -1,0 +1,12 @@
+error[E0603]: module `__seal_t` is private
+  --> $DIR/03-private-by-default.rs:17:1
+   |
+17 | #[sealed]
+   | ^^^^^^^^^ private module
+   |
+note: the module `__seal_t` is defined here
+  --> $DIR/03-private-by-default.rs:8:17
+   |
+8  |                 #[sealed]
+   |                 ^^^^^^^^^
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/fail/04-no-full-pub.rs
+++ b/tests/fail/04-no-full-pub.rs
@@ -5,7 +5,7 @@ mod lets {
         pub mod some {
             pub mod nesting {
                 use sealed::sealed;
-                #[sealed(pub(crate))]
+                #[sealed(pub)]
                 pub trait T {}
             }
         }
@@ -13,16 +13,8 @@ mod lets {
 }
 
 pub struct A;
-pub struct B {
-    field_1: i32,
-}
-pub struct C;
 
 #[sealed]
 impl lets::attempt::some::nesting::T for A {}
-#[sealed]
-impl lets::attempt::some::nesting::T for B {}
-// fails to compile
-impl lets::attempt::some::nesting::T for C {}
 
 fn main() {}

--- a/tests/fail/04-no-full-pub.stderr
+++ b/tests/fail/04-no-full-pub.stderr
@@ -1,4 +1,5 @@
-error: seal with `pub` visibility is nonsense
+error: `pub` visibility breaks the seal as allows to use it outside its crate.
+Consider tightening the visibility (e.g. `pub(crate)`) if you actually need sealing.
  --> $DIR/04-no-full-pub.rs:8:26
   |
 8 |                 #[sealed(pub)]

--- a/tests/fail/04-no-full-pub.stderr
+++ b/tests/fail/04-no-full-pub.stderr
@@ -1,0 +1,19 @@
+error: seal with `pub` visibility is nonsense
+ --> $DIR/04-no-full-pub.rs:8:26
+  |
+8 |                 #[sealed(pub)]
+  |                          ^^^
+
+error[E0433]: failed to resolve: could not find `__seal_t` in `nesting`
+  --> $DIR/04-no-full-pub.rs:17:1
+   |
+17 | #[sealed]
+   | ^^^^^^^^^ could not find `__seal_t` in `nesting`
+   |
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0405]: cannot find trait `T` in module `lets::attempt::some::nesting`
+  --> $DIR/04-no-full-pub.rs:18:36
+   |
+18 | impl lets::attempt::some::nesting::T for A {}
+   |                                    ^ not found in `lets::attempt::some::nesting`

--- a/tests/fail/05-no-comma.rs
+++ b/tests/fail/05-no-comma.rs
@@ -5,7 +5,7 @@ mod lets {
         pub mod some {
             pub mod nesting {
                 use sealed::sealed;
-                #[sealed(pub(crate))]
+                #[sealed(erase pub(crate))]
                 pub trait T {}
             }
         }
@@ -13,16 +13,8 @@ mod lets {
 }
 
 pub struct A;
-pub struct B {
-    field_1: i32,
-}
-pub struct C;
 
 #[sealed]
 impl lets::attempt::some::nesting::T for A {}
-#[sealed]
-impl lets::attempt::some::nesting::T for B {}
-// fails to compile
-impl lets::attempt::some::nesting::T for C {}
 
 fn main() {}

--- a/tests/fail/05-no-comma.stderr
+++ b/tests/fail/05-no-comma.stderr
@@ -1,0 +1,19 @@
+error: expected followed by `,`
+ --> $DIR/05-no-comma.rs:8:26
+  |
+8 |                 #[sealed(erase pub(crate))]
+  |                          ^^^^^
+
+error[E0433]: failed to resolve: could not find `__seal_t` in `nesting`
+  --> $DIR/05-no-comma.rs:17:1
+   |
+17 | #[sealed]
+   | ^^^^^^^^^ could not find `__seal_t` in `nesting`
+   |
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0405]: cannot find trait `T` in module `lets::attempt::some::nesting`
+  --> $DIR/05-no-comma.rs:18:36
+   |
+18 | impl lets::attempt::some::nesting::T for A {}
+   |                                    ^ not found in `lets::attempt::some::nesting`

--- a/tests/fail/06-wrong-argument.rs
+++ b/tests/fail/06-wrong-argument.rs
@@ -1,0 +1,11 @@
+use sealed::sealed;
+
+#[sealed(erased)]
+pub trait T {}
+
+pub struct A;
+
+#[sealed]
+impl T for A {}
+
+fn main() {}

--- a/tests/fail/06-wrong-argument.stderr
+++ b/tests/fail/06-wrong-argument.stderr
@@ -1,0 +1,19 @@
+error: unknown `erased` attribute argument
+ --> $DIR/06-wrong-argument.rs:3:10
+  |
+3 | #[sealed(erased)]
+  |          ^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared crate or module `__seal_t`
+ --> $DIR/06-wrong-argument.rs:8:1
+  |
+8 | #[sealed]
+  | ^^^^^^^^^ use of undeclared crate or module `__seal_t`
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0405]: cannot find trait `T` in this scope
+ --> $DIR/06-wrong-argument.rs:9:6
+  |
+9 | impl T for A {}
+  |      ^ not found in this scope

--- a/tests/pass/01-long-name.rs
+++ b/tests/pass/01-long-name.rs
@@ -5,7 +5,7 @@ mod lets {
         pub mod some {
             pub mod nesting {
                 use sealed::sealed;
-                #[sealed]
+                #[sealed(pub(crate))]
                 pub trait LongerSnakeCaseType {}
             }
         }
@@ -23,6 +23,4 @@ impl lets::attempt::some::nesting::LongerSnakeCaseType for A {}
 #[sealed]
 impl lets::attempt::some::nesting::LongerSnakeCaseType for B {}
 
-fn main() {
-    return;
-}
+fn main() {}

--- a/tests/pass/02-nesting.rs
+++ b/tests/pass/02-nesting.rs
@@ -5,7 +5,7 @@ mod lets {
         pub mod some {
             pub mod nesting {
                 use sealed::sealed;
-                #[sealed]
+                #[sealed(pub(in super::super::super::super))]
                 pub trait T {}
             }
         }
@@ -24,6 +24,4 @@ impl lets::attempt::some::nesting::T for A {}
 #[sealed]
 impl lets::attempt::some::nesting::T for B {}
 
-fn main() {
-    return;
-}
+fn main() {}

--- a/tests/pass/04-multiple-traits.rs
+++ b/tests/pass/04-multiple-traits.rs
@@ -19,6 +19,4 @@ impl T1 for A {}
 #[sealed]
 impl T1 for B {}
 
-fn main() {
-    return;
-}
+fn main() {}

--- a/tests/pass/06-bounds.rs
+++ b/tests/pass/06-bounds.rs
@@ -1,5 +1,8 @@
 use sealed::sealed;
+
 trait Foo {}
+
 #[sealed(erase)]
 trait Trait<T: ?Sized + Foo> {}
+
 fn main() {}

--- a/tests/pass/10-all-arguments.rs
+++ b/tests/pass/10-all-arguments.rs
@@ -1,0 +1,11 @@
+use sealed::sealed;
+
+pub enum Enum {}
+
+#[sealed(erase, pub(crate))]
+pub trait Sealer {}
+
+#[sealed]
+impl Sealer for Enum {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #9 

Bumps up crate to `0.3.0` version as using private visibility by default is a breaking change.

- [x] Tests added
- [x] Documentation and README are updated
- [x] Examples and demo are updated 