### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ proc-macro = true
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["extra-traits"] }
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-heck = "0.3"
+heck = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 
 use std::fmt;
 
-use heck::SnakeCase;
+use heck::ToSnakeCase as _;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};

--- a/tests/fail/01-general.stderr
+++ b/tests/fail/01-general.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the trait bound `C: Sealed` is not satisfied
-  --> tests/fail/01-general.rs:20:6
+  --> tests/fail/01-general.rs:20:12
    |
 20 | impl T for C {}
-   |      ^ the trait `Sealed` is not implemented for `C`
+   |            ^ the trait `Sealed` is not implemented for `C`
    |
+   = help: the following other types implement trait `Sealed`:
+             A
+             B
 note: required by a bound in `T`
   --> tests/fail/01-general.rs:11:1
    |
 11 | #[sealed]
    | ^^^^^^^^^ required by this bound in `T`
 12 | trait T {}
-   |       - required by a bound in this
+   |       - required by a bound in this trait
    = note: this error originates in the attribute macro `sealed` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/fail/02-nesting.stderr
+++ b/tests/fail/02-nesting.stderr
@@ -1,14 +1,17 @@
 error[E0277]: the trait bound `C: Sealed` is not satisfied
-  --> tests/fail/02-nesting.rs:26:6
+  --> tests/fail/02-nesting.rs:26:42
    |
 26 | impl lets::attempt::some::nesting::T for C {}
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Sealed` is not implemented for `C`
+   |                                          ^ the trait `Sealed` is not implemented for `C`
    |
+   = help: the following other types implement trait `Sealed`:
+             A
+             B
 note: required by a bound in `T`
   --> tests/fail/02-nesting.rs:8:17
    |
 8  |                 #[sealed(pub(crate))]
    |                 ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `T`
 9  |                 pub trait T {}
-   |                           - required by a bound in this
+   |                           - required by a bound in this trait
    = note: this error originates in the attribute macro `sealed` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Upgrades `syn` to 2.0 version and `heck` to 0.4 version.

Being on `syn` 1.0 blows up compilation times of projects using `sealed`, as requires to build `syn` twice.

Please, do a release after merging this PR.